### PR TITLE
Add level selection with progress tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+/local.properties
+/.idea/
+/build/
+app/build/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,63 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.marubatsuevolution"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        // Kotlin 1.9.22 is used at the project level; 1.5.9 is the compatible
+        // Compose compiler extension version.
+        kotlinCompilerExtensionVersion = "1.5.9"
+    }
+
+    packagingOptions {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.9.0")
+    // Use a recent stable Compose BOM
+    implementation(platform("androidx.compose:compose-bom:2025.05.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules for MaruBatsu Evolution

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.marubatsuevolution">
+
+    <application
+        android:allowBackup="true"
+        android:label="MaruBatsu Evolution"
+        android:icon="@android:drawable/ic_menu_help"
+        android:roundIcon="@android:drawable/ic_menu_help"
+        android:supportsRtl="true">
+        <activity android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/marubatsuevolution/Board.kt
+++ b/app/src/main/java/com/example/marubatsuevolution/Board.kt
@@ -1,0 +1,70 @@
+package com.example.marubatsuevolution
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Board(
+    size: Int,
+    board: List<List<Player?>>, 
+    blocked: Set<Pair<Int, Int>>,
+    isAbilitySelectionMode: Boolean,
+    currentPlayer: Player,
+    onTap: (Int, Int) -> Unit
+) {
+    Column {
+        for (row in 0 until size) {
+            Row {
+                for (col in 0 until size) {
+                    val isBlocked = blocked.contains(row to col)
+                    val isOwnMark = board[row][col] == currentPlayer
+                    val isTarget = isAbilitySelectionMode && isOwnMark && !isBlocked
+                    Cell(board[row][col], isBlocked, isTarget) { onTap(row, col) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun Cell(player: Player?, blocked: Boolean, isAbilityTarget: Boolean, onTap: () -> Unit) {
+    val cellSize: Dp = 64.dp
+    val symbol = when {
+        blocked -> "■"
+        player != null -> player.symbol
+        else -> ""
+    }
+    val clickableModifier = if (blocked) Modifier else Modifier.clickable {
+        if (player == null || isAbilityTarget) onTap()
+    }
+    Box(
+        modifier = Modifier
+            .size(cellSize)
+            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.onBackground))
+            .background(
+                when {
+                    blocked -> Color.LightGray
+                    isAbilityTarget -> Color.Yellow.copy(alpha = 0.5f)
+                    else -> MaterialTheme.colorScheme.surface
+                }
+            )
+            .then(clickableModifier),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = symbol)
+    }
+}

--- a/app/src/main/java/com/example/marubatsuevolution/GameState.kt
+++ b/app/src/main/java/com/example/marubatsuevolution/GameState.kt
@@ -1,0 +1,27 @@
+package com.example.marubatsuevolution
+
+// Enum representing players
+enum class Player(val symbol: String) {
+    X("X"), O("O")
+}
+
+// Enum for current screen of the app
+enum class AppScreen {
+    GAME,
+    LEVEL_SELECT
+}
+
+// Holds all game related state
+data class GameState(
+    val level: Int = 1,
+    val boardSize: Int = 3,
+    val board: List<List<Player?>> = List(3) { List<Player?>(3) { null } },
+    val blocked: Set<Pair<Int, Int>> = emptySet(),
+    val currentPlayer: Player = Player.X,
+    val winner: Player? = null,
+    val isDraw: Boolean = false,
+    val isXAbilityUsed: Boolean = false,
+    val isAbilitySelectionMode: Boolean = false,
+    val highestUnlockedLevel: Int = 1,
+    val currentAppScreen: AppScreen = AppScreen.GAME
+)

--- a/app/src/main/java/com/example/marubatsuevolution/GameViewModel.kt
+++ b/app/src/main/java/com/example/marubatsuevolution/GameViewModel.kt
@@ -1,0 +1,301 @@
+package com.example.marubatsuevolution
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.random.Random
+
+class GameViewModel(application: Application) : AndroidViewModel(application) {
+    private val repo = ProgressRepository(application)
+
+    private val _state = MutableStateFlow(GameState())
+    val state: GameState get() = _state.value
+    val stateFlow: StateFlow<GameState> = _state
+
+    init {
+        viewModelScope.launch {
+            val savedLevel = repo.currentLevel.first()
+            val savedHighest = repo.highestUnlockedLevel.first()
+            startNewGame(savedLevel, savedHighest)
+        }
+    }
+
+    fun onCellTapped(row: Int, col: Int) {
+        val s = _state.value
+        if (s.isAbilitySelectionMode) {
+            onAbilityCellSelected(row, col)
+            return
+        }
+        if (s.winner != null || s.isDraw || s.blocked.contains(row to col) || s.board[row][col] != null) return
+
+        val newBoard = s.board.toMutableList().apply {
+            this[row] = this[row].toMutableList().apply {
+                this[col] = s.currentPlayer
+            }
+        }.toList()
+
+        val winner = checkWinner(s.boardSize, newBoard)
+        val isDraw = winner == null && isBoardFull(newBoard, s.blocked)
+
+        _state.value = s.copy(
+            board = newBoard,
+            currentPlayer = if (s.currentPlayer == Player.X) Player.O else Player.X,
+            winner = winner,
+            isDraw = isDraw
+        )
+
+        if (winner != null || isDraw) {
+            onGameOver(winner)
+        } else if (_state.value.level >= 5 && _state.value.currentPlayer == Player.O) {
+            aiMove()
+        }
+    }
+
+    fun activateAbilitySelection() {
+        val s = _state.value
+        if (s.level >= 4 && s.currentPlayer == Player.X && !s.isXAbilityUsed && s.winner == null && !s.isDraw) {
+            _state.value = s.copy(isAbilitySelectionMode = true)
+        }
+    }
+
+    private fun onAbilityCellSelected(row: Int, col: Int) {
+        val s = _state.value
+        if (!s.isAbilitySelectionMode) return
+        if (s.currentPlayer != Player.X || s.isXAbilityUsed) {
+            _state.value = s.copy(isAbilitySelectionMode = false)
+            return
+        }
+        if (s.board[row][col] != Player.X) {
+            _state.value = s.copy(isAbilitySelectionMode = false)
+            return
+        }
+
+        val newBoard = s.board.toMutableList().apply {
+            this[row] = this[row].toMutableList().apply {
+                this[col] = null
+            }
+        }.toList()
+
+        _state.value = s.copy(
+            board = newBoard,
+            isXAbilityUsed = true,
+            isAbilitySelectionMode = false,
+            currentPlayer = Player.O
+        )
+
+        if (_state.value.level >= 5 && _state.value.currentPlayer == Player.O) {
+            aiMove()
+        }
+    }
+
+    fun restartGame() {
+        startNewGame(state.level, state.highestUnlockedLevel)
+    }
+
+    fun playSelectedLevel(level: Int) {
+        viewModelScope.launch {
+            val currentHighestUnlocked = repo.highestUnlockedLevel.first()
+            startNewGame(level, currentHighestUnlocked)
+            _state.value = _state.value.copy(currentAppScreen = AppScreen.GAME)
+        }
+    }
+
+    fun restartCurrentGameOrNextLevel(isWin: Boolean) {
+        viewModelScope.launch {
+            if (isWin) {
+                val newLevel = state.level + 1
+                repo.setCurrentGameLevel(newLevel)
+                if (newLevel > state.highestUnlockedLevel) {
+                    repo.setHighestUnlockedLevel(newLevel)
+                    _state.value = _state.value.copy(highestUnlockedLevel = newLevel)
+                }
+                startNewGame(newLevel, _state.value.highestUnlockedLevel)
+            } else {
+                startNewGame(state.level, state.highestUnlockedLevel)
+            }
+        }
+    }
+
+    fun navigateToLevelSelect() {
+        _state.value = _state.value.copy(currentAppScreen = AppScreen.LEVEL_SELECT)
+    }
+
+    fun navigateToGame() {
+        _state.value = _state.value.copy(currentAppScreen = AppScreen.GAME)
+    }
+
+    private fun onGameOver(winner: Player?) {
+        viewModelScope.launch {
+            if (winner != null) {
+                val newLevelForCurrentGame = state.level + 1
+                repo.setCurrentGameLevel(newLevelForCurrentGame)
+                if (newLevelForCurrentGame > state.highestUnlockedLevel) {
+                    repo.setHighestUnlockedLevel(newLevelForCurrentGame)
+                    _state.value = _state.value.copy(highestUnlockedLevel = newLevelForCurrentGame)
+                }
+                startNewGame(newLevelForCurrentGame, _state.value.highestUnlockedLevel)
+            } else if (state.isDraw) {
+                startNewGame(state.level, state.highestUnlockedLevel)
+            }
+        }
+    }
+
+    private fun startNewGame(levelToStart: Int, initialHighestUnlocked: Int) {
+        val size = if (levelToStart >= 2) 4 else 3
+        val board = List(size) { List<Player?>(size) { null } }
+        val blocked = generateBlockedCells(levelToStart, size)
+        _state.value = GameState(
+            level = levelToStart,
+            boardSize = size,
+            board = board,
+            blocked = blocked,
+            currentPlayer = Player.X,
+            winner = null,
+            isDraw = false,
+            isXAbilityUsed = false,
+            isAbilitySelectionMode = false,
+            highestUnlockedLevel = initialHighestUnlocked,
+            currentAppScreen = AppScreen.GAME
+        )
+    }
+
+    private fun generateBlockedCells(level: Int, size: Int): Set<Pair<Int, Int>> {
+        // Determine how many cells should be blocked based on the current level.
+        val numBlocked = when {
+            level < 3 -> 0                 // Lv.1-2: no blocked cells
+            level < 5 -> 2                 // Lv.3-4: 2 blocked cells
+            level < 7 -> 3                 // Lv.5-6: 3 blocked cells
+            else -> 4                      // Lv.7+: 4 blocked cells
+        }
+
+        if (numBlocked == 0) return emptySet()
+
+        val cells = mutableSetOf<Pair<Int, Int>>()
+        val random = Random(System.currentTimeMillis())
+        while (cells.size < numBlocked) {
+            val r = random.nextInt(size)
+            val c = random.nextInt(size)
+            cells += r to c
+        }
+        return cells
+    }
+
+    private fun checkWinner(size: Int, board: List<List<Player?>>): Player? {
+        for (i in 0 until size) {
+            if (board[i].all { it == Player.X }) return Player.X
+            if (board[i].all { it == Player.O }) return Player.O
+            if ((0 until size).all { board[it][i] == Player.X }) return Player.X
+            if ((0 until size).all { board[it][i] == Player.O }) return Player.O
+        }
+        if ((0 until size).all { board[it][it] == Player.X }) return Player.X
+        if ((0 until size).all { board[it][it] == Player.O }) return Player.O
+        if ((0 until size).all { board[it][size - it - 1] == Player.X }) return Player.X
+        if ((0 until size).all { board[it][size - it - 1] == Player.O }) return Player.O
+        return null
+    }
+
+    private fun isBoardFull(board: List<List<Player?>>, blocked: Set<Pair<Int, Int>>): Boolean {
+        for (r in board.indices) {
+            for (c in board[r].indices) {
+                if ((r to c) !in blocked && board[r][c] == null) return false
+            }
+        }
+        return true
+    }
+
+    private fun minimax(
+        board: List<MutableList<Player?>>, blocked: Set<Pair<Int, Int>>, size: Int,
+        maximizing: Boolean, depth: Int
+    ): Int {
+        val winner = checkWinner(size, board)
+        if (winner == Player.O) return 10 - depth
+        if (winner == Player.X) return depth - 10
+        if (isBoardFull(board, blocked)) return 0
+
+        return if (maximizing) {
+            var best = Int.MIN_VALUE
+            for (r in 0 until size) {
+                for (c in 0 until size) {
+                    if (board[r][c] == null && (r to c) !in blocked) {
+                        board[r][c] = Player.O
+                        val score = minimax(board, blocked, size, false, depth + 1)
+                        board[r][c] = null
+                        best = max(best, score)
+                    }
+                }
+            }
+            best
+        } else {
+            var best = Int.MAX_VALUE
+            for (r in 0 until size) {
+                for (c in 0 until size) {
+                    if (board[r][c] == null && (r to c) !in blocked) {
+                        board[r][c] = Player.X
+                        val score = minimax(board, blocked, size, true, depth + 1)
+                        board[r][c] = null
+                        best = min(best, score)
+                    }
+                }
+            }
+            best
+        }
+    }
+
+    private fun findBestMove(board: List<MutableList<Player?>>, blocked: Set<Pair<Int, Int>>, size: Int): Pair<Int, Int>? {
+        var bestScore = Int.MIN_VALUE
+        var move: Pair<Int, Int>? = null
+        for (r in 0 until size) {
+            for (c in 0 until size) {
+                if (board[r][c] == null && (r to c) !in blocked) {
+                    board[r][c] = Player.O
+                    val score = minimax(board, blocked, size, false, 0)
+                    board[r][c] = null
+                    if (score > bestScore) {
+                        bestScore = score
+                        move = r to c
+                    }
+                }
+            }
+        }
+        return move
+    }
+
+    private fun aiMove() {
+        val s = _state.value
+        val currentMutableBoard = s.board.map { it.toMutableList() }.toMutableList()
+        val move = findBestMove(currentMutableBoard, s.blocked, s.boardSize)
+
+        if (move == null) {
+            val isDraw = s.winner == null && isBoardFull(s.board, s.blocked)
+            _state.value = s.copy(isDraw = isDraw)
+            if (isDraw) onGameOver(null)
+            return
+        }
+
+        val newBoard = s.board.toMutableList().apply {
+            this[move.first] = this[move.first].toMutableList().apply {
+                this[move.second] = Player.O
+            }
+        }.toList()
+
+        val winner = checkWinner(s.boardSize, newBoard)
+        val isDraw = winner == null && isBoardFull(newBoard, s.blocked)
+
+        _state.value = s.copy(
+            board = newBoard,
+            currentPlayer = Player.X,
+            winner = winner,
+            isDraw = isDraw
+        )
+
+        if (winner != null || isDraw) {
+            onGameOver(winner)
+        }
+    }
+}

--- a/app/src/main/java/com/example/marubatsuevolution/MainActivity.kt
+++ b/app/src/main/java/com/example/marubatsuevolution/MainActivity.kt
@@ -1,0 +1,134 @@
+package com.example.marubatsuevolution
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import com.example.marubatsuevolution.ui.theme.MaruBatsuEvolutionTheme
+
+class MainActivity : ComponentActivity() {
+    private val viewModel: GameViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaruBatsuEvolutionTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    val state by viewModel.stateFlow.collectAsState()
+                    when (state.currentAppScreen) {
+                        AppScreen.GAME -> GameScreen(viewModel)
+                        AppScreen.LEVEL_SELECT -> LevelSelectScreen(viewModel)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun GameScreen(viewModel: GameViewModel) {
+    val state by viewModel.stateFlow.collectAsState()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Level: ${'$'}{state.level}")
+
+        Button(
+            onClick = { viewModel.navigateToLevelSelect() },
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+        ) {
+            Text("Select Level (Current Max: ${'$'}{state.highestUnlockedLevel})")
+        }
+
+        if (state.level >= 4 && state.currentPlayer == Player.X && !state.isXAbilityUsed && state.winner == null && !state.isDraw) {
+            Button(
+                onClick = { viewModel.activateAbilitySelection() },
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            ) {
+                Text("Use Ability (Clear your mark once)")
+            }
+        }
+
+        if (state.isAbilitySelectionMode) {
+            Text(text = "Ability Mode: Tap your mark to clear it", color = MaterialTheme.colorScheme.primary)
+        }
+
+        Board(
+            size = state.boardSize,
+            board = state.board,
+            blocked = state.blocked,
+            isAbilitySelectionMode = state.isAbilitySelectionMode,
+            currentPlayer = state.currentPlayer
+        ) { row, col ->
+            viewModel.onCellTapped(row, col)
+        }
+        if (state.winner != null) {
+            Text(text = "${'$'}{state.winner!!.symbol} Wins!")
+            Button(onClick = { viewModel.restartCurrentGameOrNextLevel(true) }) {
+                Text("Next Level")
+            }
+        } else if (state.isDraw) {
+            Text(text = "It's a Draw!")
+            Button(onClick = { viewModel.restartCurrentGameOrNextLevel(false) }) {
+                Text("Retry Level")
+            }
+        }
+    }
+}
+
+@Composable
+fun LevelSelectScreen(viewModel: GameViewModel) {
+    val state by viewModel.stateFlow.collectAsState()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(text = "Select Level", style = MaterialTheme.typography.headlineMedium)
+        Text(text = "Highest Unlocked: ${'$'}{state.highestUnlockedLevel}", style = MaterialTheme.typography.bodyLarge)
+
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(4),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items(state.highestUnlockedLevel) { idx ->
+                val levelNum = idx + 1
+                Button(onClick = { viewModel.playSelectedLevel(levelNum) }, modifier = Modifier.fillMaxWidth()) {
+                    Text("Lv $levelNum")
+                }
+            }
+        }
+
+        Button(
+            onClick = { viewModel.navigateToGame() },
+            modifier = Modifier.fillMaxWidth().padding(top = 16.dp)
+        ) { Text("Back to Current Game") }
+    }
+}

--- a/app/src/main/java/com/example/marubatsuevolution/ProgressRepository.kt
+++ b/app/src/main/java/com/example/marubatsuevolution/ProgressRepository.kt
@@ -1,0 +1,39 @@
+package com.example.marubatsuevolution
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.progressDataStore: DataStore<Preferences> by preferencesDataStore(name = "progress")
+
+class ProgressRepository(private val context: Context) {
+    companion object {
+        private val CURRENT_GAME_LEVEL_KEY = intPreferencesKey("current_game_level")
+        private val HIGHEST_UNLOCKED_LEVEL_KEY = intPreferencesKey("highest_unlocked_level")
+    }
+
+    val currentLevel: Flow<Int> = context.progressDataStore.data.map { prefs ->
+        prefs[CURRENT_GAME_LEVEL_KEY] ?: 1
+    }
+
+    val highestUnlockedLevel: Flow<Int> = context.progressDataStore.data.map { prefs ->
+        prefs[HIGHEST_UNLOCKED_LEVEL_KEY] ?: 1
+    }
+
+    suspend fun setCurrentGameLevel(value: Int) {
+        context.progressDataStore.edit { prefs ->
+            prefs[CURRENT_GAME_LEVEL_KEY] = value
+        }
+    }
+
+    suspend fun setHighestUnlockedLevel(value: Int) {
+        context.progressDataStore.edit { prefs ->
+            prefs[HIGHEST_UNLOCKED_LEVEL_KEY] = value
+        }
+    }
+}

--- a/app/src/main/java/com/example/marubatsuevolution/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/marubatsuevolution/ui/theme/Theme.kt
@@ -1,0 +1,15 @@
+package com.example.marubatsuevolution.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val ColorScheme = lightColorScheme()
+
+@Composable
+fun MaruBatsuEvolutionTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = ColorScheme,
+        content = content
+    )
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">MaruBatsu Evolution</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<resources>
+    <style name="Theme.MaruBatsuEvolution" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/teal_200</item>
+    </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g
+android.useAndroidX=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# Simplified gradle wrapper
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec gradle "${@}"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,7 @@
+
+@echo off
+
+set DIR=%~dp0
+
+"%DIR%\gradle" %*
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "marubatsu-evolution"
+include(":app")


### PR DESCRIPTION
## Summary
- introduce `GameState` data class and `AppScreen` in new `GameState.kt`
- track current and highest level in `ProgressRepository`
- update `GameViewModel` to load and save level progress and support level select navigation
- add level selection UI and navigation logic in `MainActivity`
- update Compose compiler and BOM versions

## Testing
- `./gradlew tasks` *(fails: Plugin not found due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68566002520c832287818e4cdf0c543e